### PR TITLE
中央ブロックの当たり判定とスフィア削除

### DIFF
--- a/1week2021_02/Assets/Scenes/SampleScene.unity
+++ b/1week2021_02/Assets/Scenes/SampleScene.unity
@@ -312,19 +312,32 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!65 &119167472
-BoxCollider:
+--- !u!61 &119167472
+BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 119167471}
+  m_Enabled: 1
+  m_Density: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 0
-  m_Enabled: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!23 &119167473
 MeshRenderer:
   m_ObjectHideFlags: 0

--- a/1week2021_02/Assets/changeSceneManager.cs
+++ b/1week2021_02/Assets/changeSceneManager.cs
@@ -17,7 +17,7 @@ public class changeSceneManager : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        Debug.Log(script.gameOverFlag);
+
         if (script.gameOverFlag)
         {
             ChageScene();

--- a/1week2021_02/Assets/moveCharactor.cs
+++ b/1week2021_02/Assets/moveCharactor.cs
@@ -46,7 +46,6 @@ public class moveCharactor : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        Debug.Log(gameOverFlag);
         if (transform.position == target)
         {
             SetTargetPosition();
@@ -93,6 +92,10 @@ public class moveCharactor : MonoBehaviour
                     Move();
                 }
                 break;
+            case "Cube (2)":
+                target = prevPos;
+                Move();
+                break;
         }
 
 
@@ -101,9 +104,147 @@ public class moveCharactor : MonoBehaviour
     void SetTargetPosition()
     {
 
+        GameObject obj = (GameObject)Resources.Load("downBrock");
+        GameObject lobj = (GameObject)Resources.Load("leftBrock");
+
         prevPos = target;
         if (Input.GetKey(KeyCode.RightArrow))
         {
+            target = transform.position + MOVEX;
+
+            int ran = UnityEngine.Random.Range(0, 5);
+
+            if (ran == 0)
+            {
+                Instantiate(obj, new Vector3(-1.2f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(obj, new Vector3(-0.6f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(obj, new Vector3(0.0f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(obj, new Vector3(0.6f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(obj, new Vector3(1.2f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 0)
+            {
+                Instantiate(obj, new Vector3(-1.8f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(obj, new Vector3(-2.4f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(obj, new Vector3(-3.0f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(obj, new Vector3(1.8f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(obj, new Vector3(2.4f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 0)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 1.8f, 0.0f), Quaternion.identity);
+            }
+
+
+            if (ran == 1)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 2.4f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 3.0f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 3.6f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 1.8f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 1.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 0.6f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 0f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -2.4f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -3.0f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -3.6f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -1.8f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -1.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -0.6f, 0.0f), Quaternion.identity);
+            }
+
             flag = !flag;
             vector = 1;
             if (this.transform.position.x < 4.1f)
@@ -114,6 +255,138 @@ public class moveCharactor : MonoBehaviour
         }
         if (Input.GetKey(KeyCode.LeftArrow))
         {
+            int ran = UnityEngine.Random.Range(0, 5);
+
+            if (ran == 0)
+            {
+                Instantiate(obj, new Vector3(-1.2f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(obj, new Vector3(-0.6f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(obj, new Vector3(0.0f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(obj, new Vector3(0.6f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(obj, new Vector3(1.2f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 0)
+            {
+                Instantiate(obj, new Vector3(-1.8f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(obj, new Vector3(-2.4f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(obj, new Vector3(-3.0f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(obj, new Vector3(1.8f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(obj, new Vector3(2.4f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 0)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 1.8f, 0.0f), Quaternion.identity);
+            }
+
+
+            if (ran == 1)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 2.4f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 3.0f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 3.6f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 1.8f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 1.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 0.6f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 0f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -2.4f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -3.0f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -3.6f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -1.8f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -1.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -0.6f, 0.0f), Quaternion.identity);
+            }
             flag = !flag;
             vector = 3;
             if (this.transform.position.x > -4.1f)
@@ -124,6 +397,138 @@ public class moveCharactor : MonoBehaviour
         }
         if(Input.GetKey(KeyCode.UpArrow))
         {
+            int ran = UnityEngine.Random.Range(0, 5);
+
+            if (ran == 0)
+            {
+                Instantiate(obj, new Vector3(-1.2f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(obj, new Vector3(-0.6f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(obj, new Vector3(0.0f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(obj, new Vector3(0.6f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(obj, new Vector3(1.2f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 0)
+            {
+                Instantiate(obj, new Vector3(-1.8f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(obj, new Vector3(-2.4f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(obj, new Vector3(-3.0f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(obj, new Vector3(1.8f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(obj, new Vector3(2.4f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 0)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 1.8f, 0.0f), Quaternion.identity);
+            }
+
+
+            if (ran == 1)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 2.4f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 3.0f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 3.6f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 1.8f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 1.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 0.6f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 0f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -2.4f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -3.0f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -3.6f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -1.8f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -1.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -0.6f, 0.0f), Quaternion.identity);
+            }
             flag = !flag;
             vector = 2;
             if (this.transform.position.y < 4.5f)
@@ -135,6 +540,138 @@ public class moveCharactor : MonoBehaviour
 
         if (Input.GetKey(KeyCode.DownArrow))
         {
+            int ran = UnityEngine.Random.Range(0, 5);
+
+            if (ran == 0)
+            {
+                Instantiate(obj, new Vector3(-1.2f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(obj, new Vector3(-0.6f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(obj, new Vector3(0.0f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(obj, new Vector3(0.6f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(obj, new Vector3(1.2f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 0)
+            {
+                Instantiate(obj, new Vector3(-1.8f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(obj, new Vector3(-2.4f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(obj, new Vector3(-3.0f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(obj, new Vector3(1.8f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(obj, new Vector3(2.4f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 0)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 1.8f, 0.0f), Quaternion.identity);
+            }
+
+
+            if (ran == 1)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 2.4f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 3.0f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 3.6f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 1.8f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 1.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 0.6f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, 0f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -2.4f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -3.0f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -3.6f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 4)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -4.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 1)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -1.8f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 2)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -1.2f, 0.0f), Quaternion.identity);
+            }
+
+            if (ran == 3)
+            {
+                Instantiate(lobj, new Vector3(-4.2f, -0.6f, 0.0f), Quaternion.identity);
+            }
             flag = !flag;
             vector = 0;
             if (this.transform.position.y > -4.1f)


### PR DESCRIPTION
中央のブロックに当たり判定を付与し、キャラがぶつかっても進まず、ゲームも止まらないように調整

デモ用に入れていたスフィアを削除し、キャラのみでブロックが生成されるように調整